### PR TITLE
Feature/1.6.0

### DIFF
--- a/Alembic.playground/Contents.swift
+++ b/Alembic.playground/Contents.swift
@@ -1,11 +1,10 @@
+/*:
+ ## Welcome to `Alembic` Playground!!
+ ----
+ > 1. Open Alembic.xcworkspace.
+ > 2. Build the Alembic-iOS.
+ > 3. Open Alembic playground in project navigator.
+ > 4. Enjoy the Alembic!
+*/
 import UIKit
 import Alembic
-
-/*
- ## Welcome to `Alembic` Playground!!
-    
- - Open Alembic.xcworkspace
- - Build Alembic
- - Then, open Alembic playground in Alembic.xcworkspace tree view.
- - Enjoy Alembic!
-*/

--- a/Alembic.playground/contents.xcplayground
+++ b/Alembic.playground/contents.xcplayground
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios'>
-    <timeline fileName='timeline.xctimeline'/>
-</playground>
+<playground version='6.0' target-platform='ios' display-mode='rendered'/>

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ throw DistillError.FilteredValue</td>
 </tr>
 
 <tr>
-<td>flatMap(ErrorType throws -> (U: DistillateType)</td>
+<td>flatMapError(ErrorType throws -> (U: DistillateType)</td>
 <td>If the error thrown, flatMap its error.</td>
 <td>U.Value</td>
 <td>throw</td>
@@ -471,22 +471,25 @@ let date: NSDate = j["time_string"].distil(String)  // "Apr 1, 2016, 12:00 AM"
 ```
 
 __Tips__
-You can create `Distillate` by  `Distillate<Value>.just(v)` or `Distillate<Value>.filter()`.  
+You can create `Distillate` by  `Distillate.just(value)`, `Distillate.filter()` and `Distillate.error(error)`.  
 It's provide more convenience to value-transformation.  
 Example:  
 
 ```Swift
+struct FindAppleError: ErrorType {}
+
 let message: String = try j.distil("number_of_apples")(Int)
     .flatMap { count -> Distillate<String> in
-        count < 0 ? .just("\(count) apples found!!") : .filter()
+        count > 0 ? .just("\(count) apples found!!") : .filter()
     }
+    .flatMapError { _ in Distillate.error(FindAppleError()) }
     .catchReturn { "Anything not found... | Error: \($0)" }
 ```
 
 ### Error handling
 Alembic has simple error handling designs as following.  
 
-__DistilError__
+__DistillError__
 - case MissingPath(JSONPath)  
 - case TypeMismatch(expected: Any.Type, actual: AnyObject)  
 - case FilteredValue(type: Any.Type, value: Any)  

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ do {
 ## Features
 - [x] JSON parsing with ease
 - [x] Mapping JSON to objects
-- [x] Type-safe serialize object to JSON
-- [x] Powerful parsed value transformation
-- [x] Error handling
+- [x] Serialize objects to JSON
+- [x] Powerful value transformation
+- [x] Fail safety
 - [x] class, struct, enum support with non-optional `let` properties
-- [x] Functional, Protocol-oriented designs
-- [x] Flexible syntax
+- [x] Functional, Protocol-oriented programming
+- [x] Flexible syntaxes
 
 ---
 
@@ -193,27 +193,28 @@ __Default supported types__
 
 __Example__
 ```Swift
-let jsonObject = [
-    "string_key": "string",  
-    "array_key": [1, 2, 3, 4, 5],
-]
+let jsonObject = ["key": "string"]
 let j = JSON(jsonObject)
 ```
 function
 ```Swift
-let string: String = try j.distil("string_key")  // "string"
-let array = try j.distil("array_key").to([Int])  // [1, 2, 3, 4, 5]
+let string: String = try j.distil("key")  // "string"
 ```
 custom operator  
 ```Swift
-let string: String = try j <| "string_key"  // "string"
-let array = try (j <| "array_key").to([Int])  // [1, 2, 3, 4, 5]
+let string: String = try j <| "key"  // "string"
 ```
 subscript
 ```Swift
-let string: String = try j["string_key"].distil()  // "string"
-let array = try j["array_key"].to([Int])  // [1, 2, 3, 4, 5]
+let string: String = try j["key"].distil()  // "string"
 ```
+
+__Tips__
+You can set the generic type as following:
+```Swift
+let string = try j.distil("key").to(String)  // "string"
+```
+It's same if use operator or subscript
 
 ### Nested objects parsing
 Supports parsing nested objects with keys and indexes.  
@@ -222,9 +223,7 @@ Keys and indexes can be summarized in the same array.
 __Example__
 ```Swift
 let jsonObject = [
-    "nested": [        
-        "array": [1, 2, 3, 4, 5]
-    ]
+    "nested": ["array": [1, 2, 3, 4, 5]]
 ]
 let j = JSON(jsonObject)
 ```
@@ -270,15 +269,13 @@ If implement `Distillable` protocol to existing classes like `NSURL`, it be able
 
 __Example__
 ```Swift
-let jsonObject = [
-    "key": "http://example.com"
-]
+let jsonObject = ["key": "http://example.com"]
 let j = JSON(jsonObject)
 ```
 ```Swift
 extension NSURL: Distillable {
     public static func distil(j: JSON) throws -> Self {
-        return try j.distil().map(self.init(string:)).filterNil()
+        return try j.distil().flatMap(self.init(string:))
     }
 }
 
@@ -294,7 +291,7 @@ __Example__
 let jsonObject = [
     "key": [
         "string_key": "string",
-        "int_key": 100
+        "option_int_key": NSNull()
     ]
 ]
 let j = JSON(jsonObject)
@@ -307,7 +304,7 @@ struct Sample: Distillable {
     static func distil(j: JSON) throws -> Sample {
         return try Sample(
             string: j <| "string_key",
-            int: j <|? "int_key"
+            int: j <|? "option_int_key"
         )
     }
 }
@@ -317,7 +314,7 @@ let sample: Sample = try j <| "key"  // Sample
 
 ### Value transformation
 Alembic supports functional value transformation during the parsing process like `String` -> `NSDate`.  
-Functions that extract value from JSON are possible to return Distillates.  
+Functions that extract value from JSON are possible to return `Distillate` object.  
 So, you can use 'map' 'flatMap' and other following useful functions.  
 
 <table>
@@ -348,8 +345,17 @@ So, you can use 'map' 'flatMap' and other following useful functions.
 </tr>
 
 <tr>
-<td>filter(Value -> Bool)</td>
-<td>If the value is filtered by predicates.<br>
+<td>flatMap(Value throws -> U?</td>
+<td>Returns the non-nil value.<br>
+If the transformed value is nil,<br>
+throw DistillError.FilteredValue</td>
+<td>U.Value</td>
+<td>throw</td>
+</tr>
+
+<tr>
+<td>filter(Value throws -> Bool)</td>
+<td>If the value is filtered by predicates,<br>
 throw DistillError.FilteredValue.</td>
 <td>Value</td>
 <td>throw</td>
@@ -379,7 +385,7 @@ Error handling is not required.</td>
 </tr>
 
 <tr>
-<td>replaceNil(() -> Value.Wrapped)</td>
+<td>replaceNil(() throws -> Value.Wrapped)</td>
 <td>If the value is nil, replace it.</td>
 <td>Value.Wrapped (might replace)</td>
 <td>throw</td>
@@ -401,7 +407,7 @@ throw DistillError.FilteredValue.</td>
 </tr>
 
 <tr>
-<td>replaceEmpty(() -> Value)</td>
+<td>replaceEmpty(() throws -> Value)</td>
 <td>If the value is empty of CollectionType, replace it.</td>
 <td>Value (might replace)</td>
 <td>throw</td>
@@ -420,43 +426,54 @@ throw DistillError.FilteredValue.</td>
 
 __Example__
 ```Swift
-let jsonObject = [
-    "time_string": "2016-04-01 00:00:00"
-]
+let jsonObject = ["time_string": "2016-04-01 00:00:00"]
 let j = JSON(jsonObject)
 ```
 function
 ```Swift
 let date: NSDate = j.distil("time_string")(String)  // "Apr 1, 2016, 12:00 AM"
-    .map { s -> NSDate? in
-        let formatter = NSDateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter.dateFromString(s)
-    }
-    .filterNil()
+    .filter { !$0.isEmpty }
+    .flatMap {
+        let fmt = NSDateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return fmt.dateFromString($0)
+    }  
     .catchReturn(NSDate())
 ```
 custom operator
 ```Swift
 let date: NSDate = (j <| "time_string")(String)  // "Apr 1, 2016, 12:00 AM"
-    .map { s -> NSDate? in
-        let formatter = NSDateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter.dateFromString(s)
+    .filter { !$0.isEmpty }
+    .flatMap {
+        let fmt = NSDateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return fmt.dateFromString($0)
     }
-    .filterNil()
     .catchReturn(NSDate())
 ```
 subscript
 ```Swift
 let date: NSDate = j["time_string"].distil(String)  // "Apr 1, 2016, 12:00 AM"
-    .map { s -> NSDate? in
-        let formatter = NSDateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter.dateFromString(s)
-    }
-    .filterNil()
+    .filter { !$0.isEmpty }
+    .flatMap {
+        let fmt = NSDateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return fmt.dateFromString($0)
+    }    
     .catchReturn(NSDate())
+```
+
+__Tips__
+You can create `Distillate` by  `Distillate<Value>.just(v)` or `Distillate<Value>.filter()`.  
+It's provide more convenience to value-transformation.  
+Example:  
+
+```Swift
+let message: String = try j.distil("number_of_apples")(Int)
+    .flatMap { count -> Distillate<String> in
+        count < 0 ? .just("\(count) apples found!!") : .filter()
+    }
+    .catchReturn { "Anything not found... | Error: \($0)" }
 ```
 
 ### Error handling
@@ -616,10 +633,10 @@ If you want to try Alembic, use Alembic Playground :)
 ---
 
 ## Playground
-- Open `Alembic.xcworkspace`
-- Build Alembic
-- Then, open `Alembic` playground in `Alembic.xcworkspace` tree view.
-- Enjoy Alembic!
+1. Open Alembic.xcworkspace.
+2. Build the Alembic-iOS.
+3. Open Alembic playground in project navigator.
+4. Enjoy the Alembic!
 
 ---
 
@@ -637,7 +654,7 @@ If your pull request including new function, please write test cases for it.
 Alembic is inspired by great libs
 [Argo](https://github.com/thoughtbot/Argo),
 [Himotoki](https://github.com/ikesyo/Himotoki),
-[SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON).  
+[RxSwift](https://github.com/ReactiveX/RxSwift).  
 Greatly thanks for authors!! :beers:.  
 
 ---

--- a/README.md
+++ b/README.md
@@ -349,6 +349,13 @@ So, you can use 'map' 'flatMap' and other following useful functions.
 <td>Returns the non-nil value.<br>
 If the transformed value is nil,<br>
 throw DistillError.FilteredValue</td>
+<td>U.Wrapped</td>
+<td>throw</td>
+</tr>
+
+<tr>
+<td>flatMap(ErrorType throws -> (U: DistillateType)</td>
+<td>If the error thrown, flatMap its error.</td>
 <td>U.Value</td>
 <td>throw</td>
 </tr>

--- a/Sources/Common/Operators.swift
+++ b/Sources/Common/Operators.swift
@@ -21,12 +21,12 @@ public func <| <T: Distillable>(j: JSON, path: JSONPath) -> T.Type throws -> T {
     return { _ in try j <| path }
 }
 
-public func <| <T: Distillable>(j: JSON, path: JSONPath) -> Distillate<T> {
-    return Distillate { try j <| path }
+public func <| <T: Distillable>(j: JSON, path: JSONPath) -> InsecureDistillate<T> {
+    return InsecureDistillate { try j <| path }
 }
 
-public func <| <T: Distillable>(j: JSON, path: JSONPath) -> T.Type -> Distillate<T> {
-    return  { _ in Distillate { try j <| path } }
+public func <| <T: Distillable>(j: JSON, path: JSONPath) -> T.Type -> InsecureDistillate<T> {
+    return  { _ in InsecureDistillate { try j <| path } }
 }
 
 // MARK: - distil option value functions
@@ -39,12 +39,12 @@ public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Optional<T>.Type th
     return { _ in try j <|? path }
 }
 
-public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Distillate<Optional<T>> {
-    return Distillate { try j <|? path }
+public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> InsecureDistillate<Optional<T>> {
+    return InsecureDistillate { try j <|? path }
 }
 
-public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Optional<T>.Type -> Distillate<Optional<T>> {
-    return  { _ in Distillate { try j <|? path } }
+public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Optional<T>.Type -> InsecureDistillate<Optional<T>> {
+    return  { _ in InsecureDistillate { try j <|? path } }
 }
 
 // MARK: - distil array functions
@@ -57,12 +57,12 @@ public func <| <T: Distillable>(j: JSON, path: JSONPath) -> [T].Type throws -> [
     return { _ in try j <| path }
 }
 
-public func <| <T: Distillable>(j: JSON, path: JSONPath) -> Distillate<[T]> {
-    return Distillate { try j <| path }
+public func <| <T: Distillable>(j: JSON, path: JSONPath) -> InsecureDistillate<[T]> {
+    return InsecureDistillate { try j <| path }
 }
 
-public func <| <T: Distillable>(j: JSON, path: JSONPath) -> [T].Type -> Distillate<[T]> {
-    return  { _ in Distillate { try j <| path } }
+public func <| <T: Distillable>(j: JSON, path: JSONPath) -> [T].Type -> InsecureDistillate<[T]> {
+    return  { _ in InsecureDistillate { try j <| path } }
 }
 
 // MARK: - distil option array functions
@@ -75,12 +75,12 @@ public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Optional<[T]>.Type 
     return { _ in try j <|? path }
 }
 
-public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Distillate<Optional<[T]>> {
-    return Distillate { try j <|? path }
+public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> InsecureDistillate<Optional<[T]>> {
+    return InsecureDistillate { try j <|? path }
 }
 
-public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Optional<[T]>.Type -> Distillate<Optional<[T]>> {
-    return  { _ in Distillate { try j <|? path } }
+public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Optional<[T]>.Type -> InsecureDistillate<Optional<[T]>> {
+    return  { _ in InsecureDistillate { try j <|? path } }
 }
 
 // MARK: - distil dictionary functions
@@ -93,12 +93,12 @@ public func <| <T: Distillable>(j: JSON, path: JSONPath) -> [String: T].Type thr
     return { _ in try j <| path }
 }
 
-public func <| <T: Distillable>(j: JSON, path: JSONPath) -> Distillate<[String: T]> {
-    return Distillate { try j <| path }
+public func <| <T: Distillable>(j: JSON, path: JSONPath) -> InsecureDistillate<[String: T]> {
+    return InsecureDistillate { try j <| path }
 }
 
-public func <| <T: Distillable>(j: JSON, path: JSONPath) -> [String: T].Type -> Distillate<[String: T]> {
-    return  { _ in Distillate { try j <| path } }
+public func <| <T: Distillable>(j: JSON, path: JSONPath) -> [String: T].Type -> InsecureDistillate<[String: T]> {
+    return  { _ in InsecureDistillate { try j <| path } }
 }
 
 // MARK: - distil option dictionary functions
@@ -111,10 +111,10 @@ public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Optional<[String: T
     return { _ in try j <|? path }
 }
 
-public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Distillate<Optional<[String: T]>> {
-    return Distillate { try j <|? path }
+public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> InsecureDistillate<Optional<[String: T]>> {
+    return InsecureDistillate { try j <|? path }
 }
 
-public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Optional<[String: T]>.Type -> Distillate<Optional<[String: T]>> {
-    return  { _ in Distillate { try j <|? path } }
+public func <|? <T: Distillable>(j: JSON, path: JSONPath) -> Optional<[String: T]>.Type -> InsecureDistillate<Optional<[String: T]>> {
+    return  { _ in InsecureDistillate { try j <|? path } }
 }

--- a/Sources/Distil/DistilError.swift
+++ b/Sources/Distil/DistilError.swift
@@ -1,18 +1,18 @@
 //
-//  DistilError.swift
+//  DistillError.swift
 //  Alembic
 //
 //  Created by Ryo Aoyama on 3/13/16.
 //  Copyright © 2016 Ryo Aoyama. All rights reserved.
 //
 
-public enum DistilError: ErrorType {
+public enum DistillError: ErrorType {
     case MissingPath(JSONPath)
     case TypeMismatch(expected: Any.Type, actual: AnyObject)
     case FilteredValue(type: Any.Type, value: Any)
 }
 
-extension DistilError: CustomDebugStringConvertible {    
+extension DistillError: CustomDebugStringConvertible {    
     public var debugDescription: String {
         switch self {
         case let .MissingPath(path):

--- a/Sources/Distil/DistilError.swift
+++ b/Sources/Distil/DistilError.swift
@@ -12,8 +12,8 @@ public enum DistilError: ErrorType {
     case FilteredValue(type: Any.Type, value: Any)
 }
 
-extension DistilError: CustomStringConvertible {
-    public var description: String {
+extension DistilError: CustomDebugStringConvertible {    
+    public var debugDescription: String {
         switch self {
         case let .MissingPath(path):
             return "MissingPath(\(path))"

--- a/Sources/Distil/DistilSubscripted.swift
+++ b/Sources/Distil/DistilSubscripted.swift
@@ -39,8 +39,8 @@ public extension DistilSubscripted {
         return try j.distil(path)
     }
     
-    func distil<T: Distillable>(_: T.Type = T.self) -> Distillate<T> {
-        return Distillate { try self.distil() }
+    func distil<T: Distillable>(_: T.Type = T.self) -> InsecureDistillate<T> {
+        return InsecureDistillate { try self.distil() }
     }
 }
 
@@ -51,8 +51,8 @@ public extension DistilSubscripted {
         return try j.option(path)
     }
     
-    func option<T: Distillable>(_: Optional<T>.Type = Optional<T>.self) -> Distillate<Optional<T>> {
-        return Distillate { try self.option() }
+    func option<T: Distillable>(_: Optional<T>.Type = Optional<T>.self) -> InsecureDistillate<Optional<T>> {
+        return InsecureDistillate { try self.option() }
     }
 }
 
@@ -63,8 +63,8 @@ public extension DistilSubscripted {
         return try j.distil(path)
     }
     
-    func distil<T: Distillable>(_: [T].Type = [T].self) -> Distillate<[T]> {
-        return Distillate { try self.distil() }
+    func distil<T: Distillable>(_: [T].Type = [T].self) -> InsecureDistillate<[T]> {
+        return InsecureDistillate { try self.distil() }
     }
 }
 
@@ -75,8 +75,8 @@ public extension DistilSubscripted {
         return try j.option(path)
     }
     
-    func option<T: Distillable>(_: Optional<[T]>.Type = Optional<[T]>.self) -> Distillate<Optional<[T]>> {
-        return Distillate { try self.option() }
+    func option<T: Distillable>(_: Optional<[T]>.Type = Optional<[T]>.self) -> InsecureDistillate<Optional<[T]>> {
+        return InsecureDistillate { try self.option() }
     }
 }
 
@@ -87,8 +87,8 @@ public extension DistilSubscripted {
         return try j.distil(path)
     }
     
-    func distil<T: Distillable>(_: [String: T].Type = [String: T].self) -> Distillate<[String: T]> {
-        return Distillate { try self.distil() }
+    func distil<T: Distillable>(_: [String: T].Type = [String: T].self) -> InsecureDistillate<[String: T]> {
+        return InsecureDistillate { try self.distil() }
     }
 }
 
@@ -99,7 +99,7 @@ public extension DistilSubscripted {
         return try j.option(path)
     }
     
-    func option<T: Distillable>(_: Optional<[String: T]>.Type = Optional<[String: T]>.self) -> Distillate<Optional<[String: T]>> {
-        return Distillate { try self.option() }
+    func option<T: Distillable>(_: Optional<[String: T]>.Type = Optional<[String: T]>.self) -> InsecureDistillate<Optional<[String: T]>> {
+        return InsecureDistillate { try self.option() }
     }
 }

--- a/Sources/Distil/Distillable.swift
+++ b/Sources/Distil/Distillable.swift
@@ -103,7 +103,7 @@ extension UInt64: Distillable {
 public extension RawRepresentable where Self: Distillable, RawValue: Distillable {
     static func distil(j: JSON) throws -> Self {
         guard let value = try self.init(rawValue: RawValue.distil(j)) else {
-            throw DistilError.TypeMismatch(expected: Self.self, actual: j.raw)
+            throw DistillError.TypeMismatch(expected: Self.self, actual: j.raw)
         }
         return value
     }
@@ -111,7 +111,7 @@ public extension RawRepresentable where Self: Distillable, RawValue: Distillable
 
 private func cast<T>(j: JSON) throws -> T {
     guard let value = j.raw as? T else {
-        throw DistilError.TypeMismatch(expected: T.self, actual: j.raw)
+        throw DistillError.TypeMismatch(expected: T.self, actual: j.raw)
     }
     return value
 }

--- a/Sources/Distil/Distillate.swift
+++ b/Sources/Distil/Distillate.swift
@@ -71,15 +71,15 @@ public extension DistillateType {
     }
     
     @warn_unused_result
-    func filter(@noescape predicate: Value -> Bool) throws -> Value {
+    func filter(@noescape predicate: Value throws -> Bool) throws -> Value {
         return try map {
-            if predicate($0) { return $0 }
+            if try predicate($0) { return $0 }
             throw DistilError.FilteredValue(type: Value.self, value: $0)
         }
     }
     
     @warn_unused_result
-    func filter(predicate: Value -> Bool) -> Distillate<Value> {
+    func filter(predicate: Value throws -> Bool) -> Distillate<Value> {
         return Distillate { try self.filter(predicate) }
     }
     
@@ -107,12 +107,12 @@ public extension DistillateType {
 
 public extension DistillateType where Value: OptionalType {
     @warn_unused_result
-    func replaceNil(@noescape with: () -> Value.Wrapped) throws -> Value.Wrapped {
+    func replaceNil(@noescape with: () throws -> Value.Wrapped) throws -> Value.Wrapped {
         return try value().optionalValue ?? with()
     }
     
     @warn_unused_result
-    func replaceNil(with: () -> Value.Wrapped) -> Distillate<Value.Wrapped> {
+    func replaceNil(with: () throws -> Value.Wrapped) -> Distillate<Value.Wrapped> {
         return Distillate { try self.replaceNil(with) }
     }
     
@@ -139,12 +139,12 @@ public extension DistillateType where Value: OptionalType {
 
 public extension DistillateType where Value: CollectionType {
     @warn_unused_result
-    func replaceEmpty(@noescape with: () -> Value) throws -> Value {
-        return try map { $0.isEmpty ? with() : $0 }
+    func replaceEmpty(@noescape with: () throws -> Value) throws -> Value {
+        return try map { $0.isEmpty ? try with() : $0 }
     }
     
     @warn_unused_result
-    func replaceEmpty(with: () -> Value) -> Distillate<Value> {
+    func replaceEmpty(with: () throws -> Value) -> Distillate<Value> {
         return Distillate { try self.replaceEmpty(with) }
     }
     

--- a/Sources/Distil/Distillate.swift
+++ b/Sources/Distil/Distillate.swift
@@ -66,7 +66,7 @@ public extension DistillateType {
     }
     
     @warn_unused_result
-    func flatMap<T: DistillateType>(f: Value throws -> T) throws -> Distillate<T.Value> {
+    func flatMap<T: DistillateType>(f: Value throws -> T) -> Distillate<T.Value> {
         return Distillate { try self.flatMap(f) }
     }
     

--- a/Sources/Distil/Distillate.swift
+++ b/Sources/Distil/Distillate.swift
@@ -98,6 +98,17 @@ public extension DistillateType {
     }
     
     @warn_unused_result
+    func flatMapError<T: DistillateType where T.Value == Value>(f: ErrorType throws -> T) throws -> Value {
+        do { return try value() }
+        catch let e { return try f(e).value() }
+    }
+    
+    @warn_unused_result
+    func flatMapError<T: DistillateType where T.Value == Value>(f: ErrorType throws -> T) -> InsecureDistillate<Value> {
+        return InsecureDistillate { try self.flatMapError(f) }
+    }
+    
+    @warn_unused_result
     func filter(@noescape predicate: Value throws -> Bool) throws -> Value {
         return try map {
             if try predicate($0) { return $0 }

--- a/Sources/Distil/Distillate.swift
+++ b/Sources/Distil/Distillate.swift
@@ -71,6 +71,16 @@ public extension DistillateType {
     }
     
     @warn_unused_result
+    func flatMap<T>(f: Value throws -> Optional<T>) throws -> T {
+        return try map(f).filterNil()
+    }
+    
+    @warn_unused_result
+    func flatMap<T>(f: Value throws -> Optional<T>) -> Distillate<T> {
+        return Distillate { try self.flatMap(f) }
+    }
+    
+    @warn_unused_result
     func filter(@noescape predicate: Value throws -> Bool) throws -> Value {
         return try map {
             if try predicate($0) { return $0 }

--- a/Sources/Distil/Distillate.swift
+++ b/Sources/Distil/Distillate.swift
@@ -56,8 +56,12 @@ public class Distillate<Value>: DistillateType {
         return SecureDistillate.init(element)
     }
     
+    public static func error(e: ErrorType) -> InsecureDistillate<Value> {
+        return InsecureDistillate { throw e }
+    }
+    
     public static func filter() -> InsecureDistillate<Value> {
-        return InsecureDistillate { throw DistilError.FilteredValue(type: Value.self, value: ()) }
+        return error(DistillError.FilteredValue(type: Value.self, value: ()))
     }
 }
 
@@ -112,7 +116,7 @@ public extension DistillateType {
     func filter(@noescape predicate: Value throws -> Bool) throws -> Value {
         return try map {
             if try predicate($0) { return $0 }
-            throw DistilError.FilteredValue(type: Value.self, value: $0)
+            throw DistillError.FilteredValue(type: Value.self, value: $0)
         }
     }
     

--- a/Sources/Distil/Distillate.swift
+++ b/Sources/Distil/Distillate.swift
@@ -51,6 +51,14 @@ public protocol DistillateType {
 }
 
 public extension DistillateType {
+    static func just(@autoclosure(escaping) element: () -> Value) -> SecureDistillate<Value> {
+        return SecureDistillate.init(element)
+    }
+    
+    static func filter() -> Distillate<Value> {
+        return Distillate { throw DistilError.FilteredValue(type: Value.self, value: ()) }
+    }
+    
     func map<T>(@noescape f: Value throws -> T) throws -> T {
         return try f(value())
     }

--- a/Sources/Distil/Distillate.swift
+++ b/Sources/Distil/Distillate.swift
@@ -51,7 +51,7 @@ public protocol DistillateType {
 }
 
 public extension DistillateType {
-    public func map<T>(@noescape f: Value throws -> T) throws -> T {
+    func map<T>(@noescape f: Value throws -> T) throws -> T {
         return try f(value())
     }
     
@@ -105,35 +105,35 @@ public extension DistillateType {
     }
     
     @warn_unused_result
-    func catchReturn(@autoclosure value: () -> Value) -> Value {
-        return catchReturn { _ in value() }
+    func catchReturn(@autoclosure element: () -> Value) -> Value {
+        return catchReturn { _ in element() }
     }
     
     @warn_unused_result
-    func catchReturn(@autoclosure(escaping) value: () -> Value) -> SecureDistillate<Value> {
-        return catchReturn { _ in value() }
+    func catchReturn(@autoclosure(escaping) element: () -> Value) -> SecureDistillate<Value> {
+        return catchReturn { _ in element() }
     }
 }
 
 public extension DistillateType where Value: OptionalType {
     @warn_unused_result
-    func replaceNil(@noescape with: () throws -> Value.Wrapped) throws -> Value.Wrapped {
-        return try value().optionalValue ?? with()
+    func replaceNil(@noescape handler: () throws -> Value.Wrapped) throws -> Value.Wrapped {
+        return try value().optionalValue ?? handler()
     }
     
     @warn_unused_result
-    func replaceNil(with: () throws -> Value.Wrapped) -> Distillate<Value.Wrapped> {
-        return Distillate { try self.replaceNil(with) }
+    func replaceNil(handler: () throws -> Value.Wrapped) -> Distillate<Value.Wrapped> {
+        return Distillate { try self.replaceNil(handler) }
     }
     
     @warn_unused_result
-    func replaceNil(@autoclosure with: () -> Value.Wrapped) throws -> Value.Wrapped {
-        return try replaceNil { with() }
+    func replaceNil(@autoclosure element: () -> Value.Wrapped) throws -> Value.Wrapped {
+        return try replaceNil(element)
     }
     
     @warn_unused_result
-    func replaceNil(@autoclosure(escaping) with: () -> Value.Wrapped) -> Distillate<Value.Wrapped> {
-        return replaceNil { with() }
+    func replaceNil(@autoclosure(escaping) element: () -> Value.Wrapped) -> Distillate<Value.Wrapped> {
+        return replaceNil(element)
     }
     
     @warn_unused_result
@@ -143,29 +143,29 @@ public extension DistillateType where Value: OptionalType {
     
     @warn_unused_result
     func filterNil() -> Distillate<Value.Wrapped> {
-        return Distillate { try self.filterNil() }
+        return Distillate.init(filterNil)
     }
 }
 
 public extension DistillateType where Value: CollectionType {
     @warn_unused_result
-    func replaceEmpty(@noescape with: () throws -> Value) throws -> Value {
-        return try map { $0.isEmpty ? try with() : $0 }
+    func replaceEmpty(@noescape handler: () throws -> Value) throws -> Value {
+        return try map { $0.isEmpty ? try handler() : $0 }
     }
     
     @warn_unused_result
-    func replaceEmpty(with: () throws -> Value) -> Distillate<Value> {
-        return Distillate { try self.replaceEmpty(with) }
+    func replaceEmpty(handler: () throws -> Value) -> Distillate<Value> {
+        return Distillate { try self.replaceEmpty(handler) }
     }
     
     @warn_unused_result
-    func replaceEmpty(@autoclosure with: () -> Value) throws -> Value {
-        return try replaceEmpty { with() }
+    func replaceEmpty(@autoclosure element: () -> Value) throws -> Value {
+        return try replaceEmpty(element)
     }
     
     @warn_unused_result
-    func replaceEmpty(@autoclosure(escaping) with: () -> Value) -> Distillate<Value> {
-        return replaceEmpty { with() }
+    func replaceEmpty(@autoclosure(escaping) element: () -> Value) -> Distillate<Value> {
+       return replaceEmpty(element)
     }
     
     @warn_unused_result
@@ -175,6 +175,6 @@ public extension DistillateType where Value: CollectionType {
     
     @warn_unused_result
     func filterEmpty() -> Distillate<Value> {
-        return Distillate { try self.filterEmpty() }
+        return Distillate.init(self.filterEmpty)
     }
 }

--- a/Sources/Distil/JSON.swift
+++ b/Sources/Distil/JSON.swift
@@ -75,15 +75,15 @@ public extension JSON {
         return try distil(path)(T)
     }
     
-    func distil<T: Distillable>(_: T.Type = T.self) -> Distillate<T> {
-        return Distillate { try self.distil() }
+    func distil<T: Distillable>(_: T.Type = T.self) -> InsecureDistillate<T> {
+        return InsecureDistillate { try self.distil() }
     }
     
-    func distil<T: Distillable>(path: JSONPath) -> T.Type -> Distillate<T> {
-        return { _ in Distillate { try self.distil(path) } }
+    func distil<T: Distillable>(path: JSONPath) -> T.Type -> InsecureDistillate<T> {
+        return { _ in InsecureDistillate { try self.distil(path) } }
     }
     
-    func distil<T: Distillable>(path: JSONPath) -> Distillate<T> {
+    func distil<T: Distillable>(path: JSONPath) -> InsecureDistillate<T> {
         return distil(path)(T)
     }
 }
@@ -107,11 +107,11 @@ public extension JSON {
         return try option(path)(Optional<T>)
     }
     
-    func option<T: Distillable>(path: JSONPath) -> Optional<T>.Type -> Distillate<Optional<T>> {
-        return { _ in Distillate { try self.option(path) } }
+    func option<T: Distillable>(path: JSONPath) -> Optional<T>.Type -> InsecureDistillate<Optional<T>> {
+        return { _ in InsecureDistillate { try self.option(path) } }
     }
     
-    func option<T: Distillable>(path: JSONPath) -> Distillate<Optional<T>> {
+    func option<T: Distillable>(path: JSONPath) -> InsecureDistillate<Optional<T>> {
         return option(path)(Optional<T>)
     }
 }
@@ -135,15 +135,15 @@ public extension JSON {
         return try distil(path)([T])
     }
     
-    func distil<T: Distillable>(_: [T].Type = [T].self) -> Distillate<[T]> {
-        return Distillate { try self.distil() }
+    func distil<T: Distillable>(_: [T].Type = [T].self) -> InsecureDistillate<[T]> {
+        return InsecureDistillate { try self.distil() }
     }
     
-    func distil<T: Distillable>(path: JSONPath) -> [T].Type -> Distillate<[T]> {
-        return { _ in Distillate { try self.distil(path) } }
+    func distil<T: Distillable>(path: JSONPath) -> [T].Type -> InsecureDistillate<[T]> {
+        return { _ in InsecureDistillate { try self.distil(path) } }
     }
     
-    func distil<T: Distillable>(path: JSONPath) -> Distillate<[T]> {
+    func distil<T: Distillable>(path: JSONPath) -> InsecureDistillate<[T]> {
         return distil(path)([T])
     }
 }
@@ -167,11 +167,11 @@ public extension JSON {
         return try option(path)(Optional<[T]>)
     }
     
-    func option<T: Distillable>(path: JSONPath) -> Optional<[T]>.Type -> Distillate<Optional<[T]>> {
-        return { _ in Distillate { try self.option(path) } }
+    func option<T: Distillable>(path: JSONPath) -> Optional<[T]>.Type -> InsecureDistillate<Optional<[T]>> {
+        return { _ in InsecureDistillate { try self.option(path) } }
     }
     
-    func option<T: Distillable>(path: JSONPath) -> Distillate<Optional<[T]>> {
+    func option<T: Distillable>(path: JSONPath) -> InsecureDistillate<Optional<[T]>> {
         return option(path)(Optional<[T]>)
     }
 }
@@ -200,15 +200,15 @@ public extension JSON {
         return try distil(path)([String: T])
     }
     
-    func distil<T: Distillable>(path: JSONPath) -> [String: T].Type -> Distillate<[String: T]> {
-        return { _ in Distillate { try self.distil(path)([String: T]) } }
+    func distil<T: Distillable>(path: JSONPath) -> [String: T].Type -> InsecureDistillate<[String: T]> {
+        return { _ in InsecureDistillate { try self.distil(path)([String: T]) } }
     }
     
-    func distil<T: Distillable>(_: [String: T].Type = [String: T].self) -> Distillate<[String: T]> {
-        return Distillate { try self.distil() }
+    func distil<T: Distillable>(_: [String: T].Type = [String: T].self) -> InsecureDistillate<[String: T]> {
+        return InsecureDistillate { try self.distil() }
     }
     
-    func distil<T: Distillable>(path: JSONPath) -> Distillate<[String: T]> {
+    func distil<T: Distillable>(path: JSONPath) -> InsecureDistillate<[String: T]> {
         return distil(path)([String: T])
     }
 }
@@ -232,11 +232,11 @@ public extension JSON {
         return try option(path)(Optional<[String: T]>)
     }
     
-    func option<T: Distillable>(path: JSONPath) -> Optional<[String: T]>.Type -> Distillate<Optional<[String: T]>> {
-        return { _ in Distillate { try self.option(path) } }
+    func option<T: Distillable>(path: JSONPath) -> Optional<[String: T]>.Type -> InsecureDistillate<Optional<[String: T]>> {
+        return { _ in InsecureDistillate { try self.option(path) } }
     }
     
-    func option<T: Distillable>(path: JSONPath) -> Distillate<Optional<[String: T]>> {
+    func option<T: Distillable>(path: JSONPath) -> InsecureDistillate<Optional<[String: T]>> {
         return option(path)(Optional<[String: T]>)
     }
 }

--- a/Sources/Distil/JSON.swift
+++ b/Sources/Distil/JSON.swift
@@ -28,13 +28,13 @@ public struct JSON {
             let json = try NSJSONSerialization.JSONObjectWithData(data, options: options)
             self.init(json)
         } catch {
-            throw DistilError.TypeMismatch(expected: NSData.self, actual: data)
+            throw DistillError.TypeMismatch(expected: NSData.self, actual: data)
         }
     }
     
     public init (string: String, encoding: NSStringEncoding = NSUTF8StringEncoding, allowLossyConversion: Bool = false, options: NSJSONReadingOptions = .AllowFragments) throws {
         guard let json = string.dataUsingEncoding(encoding, allowLossyConversion: allowLossyConversion) else {
-            throw DistilError.TypeMismatch(expected: String.self, actual: string)
+            throw DistillError.TypeMismatch(expected: String.self, actual: string)
         }
         try self.init(data: json, options: options)
     }
@@ -65,8 +65,8 @@ public extension JSON {
         return { _ in
             do {
                 return try JSON(self.distilRecursive(path)).distil()
-            } catch let DistilError.MissingPath(missing) where path != missing {
-                throw DistilError.MissingPath(path + missing)
+            } catch let DistillError.MissingPath(missing) where path != missing {
+                throw DistillError.MissingPath(path + missing)
             }
         }
     }
@@ -95,9 +95,9 @@ public extension JSON {
         return { _ in
             do {
                 return try self.distil(path)(T)
-            } catch let DistilError.TypeMismatch(expected: _, actual: actual) {
-                throw DistilError.TypeMismatch(expected: Optional<T>.self, actual: actual)
-            } catch let DistilError.MissingPath(missing) where missing == path {
+            } catch let DistillError.TypeMismatch(expected: _, actual: actual) {
+                throw DistillError.TypeMismatch(expected: Optional<T>.self, actual: actual)
+            } catch let DistillError.MissingPath(missing) where missing == path {
                 return nil
             }
         }
@@ -155,9 +155,9 @@ public extension JSON {
         return { _ in
             do {
                 return try self.distil(path)([T])
-            } catch let DistilError.TypeMismatch(expected: _, actual: actual) {
-                throw DistilError.TypeMismatch(expected: Optional<[T]>.self, actual: actual)
-            } catch let DistilError.MissingPath(missing) where missing == path {
+            } catch let DistillError.TypeMismatch(expected: _, actual: actual) {
+                throw DistillError.TypeMismatch(expected: Optional<[T]>.self, actual: actual)
+            } catch let DistillError.MissingPath(missing) where missing == path {
                 return nil
             }
         }
@@ -220,9 +220,9 @@ public extension JSON {
         return { _ in
             do {
                 return try self.distil(path)([String: T])
-            } catch let DistilError.TypeMismatch(expected: _, actual: actual) {
-                throw DistilError.TypeMismatch(expected: Optional<[String: T]>.self, actual: actual)
-            } catch let DistilError.MissingPath(missing) where missing == path {
+            } catch let DistillError.TypeMismatch(expected: _, actual: actual) {
+                throw DistillError.TypeMismatch(expected: Optional<[String: T]>.self, actual: actual)
+            } catch let DistillError.MissingPath(missing) where missing == path {
                 return nil
             }
         }
@@ -302,7 +302,7 @@ private extension JSON {
                 let dictionary: [String: AnyObject] = try cast(object)
                 
                 guard let value = dictionary[key] where !(value is NSNull) else {
-                    throw DistilError.MissingPath(path)
+                    throw DistillError.MissingPath(path)
                 }
                 
                 if paths.count == 1 {
@@ -315,13 +315,13 @@ private extension JSON {
                 let array: [AnyObject] = try cast(object)
                 
                 guard array.count > index else {
-                    throw DistilError.MissingPath(path)
+                    throw DistillError.MissingPath(path)
                 }
                 
                 let value = array[index]
                 
                 if value is NSNull {
-                    throw DistilError.MissingPath(path)
+                    throw DistillError.MissingPath(path)
                 }
                 
                 if paths.count == 1 {
@@ -338,7 +338,7 @@ private extension JSON {
     
     func cast<T>(object: AnyObject) throws -> T {
         guard let value = object as? T else {
-            throw DistilError.TypeMismatch(expected: T.self, actual: object)
+            throw DistillError.TypeMismatch(expected: T.self, actual: object)
         }
         return value
     }

--- a/Sources/Distil/JSON.swift
+++ b/Sources/Distil/JSON.swift
@@ -281,10 +281,10 @@ public extension JSON {
     }
 }
 
-// MARK: - CustomStringConvertible
+// MARK: - CustomDebugStringConvertible
 
-extension JSON: CustomStringConvertible {
-    public var description: String {
+extension JSON: CustomDebugStringConvertible {
+    public var debugDescription: String {
         return "JSON(\(raw))"
     }
 }

--- a/Sources/Distil/JSONPath.swift
+++ b/Sources/Distil/JSONPath.swift
@@ -28,8 +28,8 @@ public func + (lhs: JSONPath, rhs: JSONPath) -> JSONPath {
     return JSONPath(lhs.paths + rhs.paths)
 }
 
-extension JSONPath: CustomStringConvertible {
-    public var description: String {
+extension JSONPath: CustomDebugStringConvertible {
+    public var debugDescription: String {
         return "JSONPath(\(paths))"
     }
 }
@@ -82,8 +82,8 @@ public func == (lhs: JSONPathElement, rhs: JSONPathElement) -> Bool {
     }
 }
 
-extension JSONPathElement: CustomStringConvertible {
-    public var description: String {
+extension JSONPathElement: CustomDebugStringConvertible {
+    public var debugDescription: String {
         return "\(value)"
     }
 }

--- a/Tests/DistilTests.swift
+++ b/Tests/DistilTests.swift
@@ -60,14 +60,14 @@ class DistilTests: XCTestCase {
         }
     }
     
-    func testDistilError() {
+    func testDistillError() {
         let j = JSON(object)
         
         do {
             _ = try (j <| "missing_key").to(String)
             
             XCTFail("Expect the error to occur")
-        } catch let DistilError.MissingPath(path) where path == "missing_key" {
+        } catch let DistillError.MissingPath(path) where path == "missing_key" {
             XCTAssert(true)
         } catch let e {
             XCTFail("\(e)")
@@ -77,7 +77,7 @@ class DistilTests: XCTestCase {
             _ = try (j <| "int_string").to(Int)
             
             XCTFail("Expect the error to occur")
-        } catch let DistilError.TypeMismatch(expected: expected, actual: actual) where expected == Int.self && actual as? String == "1" {
+        } catch let DistillError.TypeMismatch(expected: expected, actual: actual) where expected == Int.self && actual as? String == "1" {
             XCTAssert(expected == Int.self)
             XCTAssertEqual(actual as? String, "1")
         } catch let e {
@@ -128,7 +128,7 @@ class DistilTests: XCTestCase {
 extension NSURL: Distillable {
     public static func distil(j: JSON) throws -> Self {
         guard let url = try self.init(string: j.distil()) else {
-            throw DistilError.TypeMismatch(expected: NSURL.self, actual: j.raw)
+            throw DistillError.TypeMismatch(expected: NSURL.self, actual: j.raw)
         }
         return url
     }

--- a/Tests/OptionalTests.swift
+++ b/Tests/OptionalTests.swift
@@ -43,7 +43,7 @@ class OptionalTests: XCTestCase {
             _ = try (j <|? "string").to(Int?)
             
             XCTFail("Expect the error to occur")
-        } catch let DistilError.TypeMismatch(expected: expected, actual: actual) {
+        } catch let DistillError.TypeMismatch(expected: expected, actual: actual) {
             XCTAssert(expected == Int?.self)
             XCTAssertEqual(actual as? String, "Alembic")
         } catch let e {
@@ -74,7 +74,7 @@ class OptionalTests: XCTestCase {
             _ = try j["string"].option().to(Int?)
             
             XCTFail("Expect the error to occur")
-        } catch let DistilError.TypeMismatch(expected: expected, actual: actual) {
+        } catch let DistillError.TypeMismatch(expected: expected, actual: actual) {
             XCTAssert(expected == Int?.self)
             XCTAssertEqual(actual as? String, "Alembic")
         } catch let e {
@@ -89,7 +89,7 @@ class OptionalTests: XCTestCase {
             _ = try (j <|? "int").to(String?)
             
             XCTFail("Expect the error to occur")
-        } catch let DistilError.TypeMismatch(expected: expected, actual: actual) {
+        } catch let DistillError.TypeMismatch(expected: expected, actual: actual) {
             XCTAssert(expected == String?.self)
             XCTAssertEqual(actual as? Int, 777)
         } catch let e {
@@ -118,7 +118,7 @@ class OptionalTests: XCTestCase {
             XCTFail("Expected the error to occur")
         } catch let e {
             switch e {
-            case let DistilError.MissingPath(path):
+            case let DistillError.MissingPath(path):
                 XCTAssert(path == ["user2", "contact", "email"])
             default:
                 XCTFail("\(e)")

--- a/Tests/TransformTests.swift
+++ b/Tests/TransformTests.swift
@@ -115,4 +115,45 @@ class TransformTests: XCTestCase {
             XCTFail("\(e)")
         }
     }
+    
+    func testJustAndFilter() {
+        let j = JSON(object)
+        
+        let just = Distillate<String>.just("just")
+        XCTAssertEqual(just.to(String), "just")
+        
+        do {
+            let filter = Distillate<String>.filter()
+            _ = try filter.to(String)
+            
+            XCTFail("Expect the error to occur")
+        } catch let DistilError.FilteredValue(type: type, value: value) {
+            XCTAssertNotNil(type as? String.Type)
+            XCTAssertNotNil(value as? Void)
+        } catch let e {
+            XCTFail("\(e)")
+        }
+        
+        do {
+            let flatMapJust: String = try (j <| "key")(String)
+                .flatMap { _ in Distillate<String>.just("just") }
+            
+            XCTAssertEqual(flatMapJust, "just")
+        } catch let e {
+            XCTFail("\(e)")
+        }
+        
+        do {
+            _ = try (j <| "key")(String)
+                .flatMap { _ in Distillate<String>.filter() }
+                .to(String)
+            
+            XCTFail("Expect the error to occur")
+        } catch let DistilError.FilteredValue(type: type, value: value) {
+            XCTAssertNotNil(type as? String.Type)
+            XCTAssertNotNil(value as? Void)
+        } catch let e {
+            XCTFail("\(e)")
+        }
+    }
 }

--- a/Tests/TransformTests.swift
+++ b/Tests/TransformTests.swift
@@ -20,18 +20,34 @@ class TransformTests: XCTestCase {
                 .map { "map_" + $0 }
             let flatMap: String = try (j <| ["nested", "nested_key"])(String)
                 .flatMap { v -> Distillate<String> in (j <| "key").map { "flatMap_" + $0 + "_with_" + v } }
+            let flatMapOptional: String? = try (j <| ["nested", "nested_key"])(String)
+                .flatMap { Optional<String>.Some($0) }
             let catchUp: String = (j <| "error")
-                .catchReturn("catch_up")
+                .catchReturn("catch_return")
             let replaceNil: String = try (j <|? "null")
-                .replaceNil("remap_nil")
+                .replaceNil("replace_nil")
             let replaceEmpty: [String] = try (j <| "array")
-                .replaceEmpty(["remap_empty"])
+                .replaceEmpty(["replace_empty"])
             
             XCTAssertEqual(map, "map_value")
             XCTAssertEqual(flatMap, "flatMap_value_with_nested_value")
-            XCTAssertEqual(catchUp, "catch_up")
-            XCTAssertEqual(replaceNil, "remap_nil")
-            XCTAssertEqual(replaceEmpty, ["remap_empty"])
+            XCTAssertEqual(flatMapOptional, "nested_value")
+            XCTAssertEqual(catchUp, "catch_return")
+            XCTAssertEqual(replaceNil, "replace_nil")
+            XCTAssertEqual(replaceEmpty, ["replace_empty"])
+        } catch let e {
+            XCTFail("\(e)")
+        }
+        
+        do {
+            _ = try (j <| "key")(String)
+                .flatMap { _ in nil }
+                .to(String)
+            
+            XCTFail("Expect the error to occur")
+        } catch let DistilError.FilteredValue(type, value) {
+            XCTAssertNotNil(type as? Optional<String>.Type)
+            XCTAssertNotNil(value)
         } catch let e {
             XCTFail("\(e)")
         }

--- a/Tests/TransformTests.swift
+++ b/Tests/TransformTests.swift
@@ -19,7 +19,7 @@ class TransformTests: XCTestCase {
             let map: String = try (j <| "key")
                 .map { "map_" + $0 }
             let flatMap: String = try (j <| ["nested", "nested_key"])(String)
-                .flatMap { v -> Distillate<String> in return (j <| "key").map { "flatMap_" + $0 + "_with_" + v } }
+                .flatMap { v -> Distillate<String> in (j <| "key").map { "flatMap_" + $0 + "_with_" + v } }
             let catchUp: String = (j <| "error")
                 .catchReturn("catch_up")
             let replaceNil: String = try (j <|? "null")

--- a/Tests/TransformTests.swift
+++ b/Tests/TransformTests.swift
@@ -22,6 +22,8 @@ class TransformTests: XCTestCase {
                 .flatMap { v -> Distillate<String> in (j <| "key").map { "flatMap_" + $0 + "_with_" + v } }
             let flatMapOptional: String? = try (j <| ["nested", "nested_key"])(String)
                 .flatMap { Optional<String>.Some($0) }
+            let flatMapError: String = try (j <| "missing_key")(String)
+                .flatMapError { _ in Distillate<String>.just("flat_map_error") }
             let catchUp: String = (j <| "error")
                 .catchReturn("catch_return")
             let replaceNil: String = try (j <|? "null")
@@ -32,6 +34,7 @@ class TransformTests: XCTestCase {
             XCTAssertEqual(map, "map_value")
             XCTAssertEqual(flatMap, "flatMap_value_with_nested_value")
             XCTAssertEqual(flatMapOptional, "nested_value")
+            XCTAssertEqual(flatMapError, "flat_map_error")
             XCTAssertEqual(catchUp, "catch_return")
             XCTAssertEqual(replaceNil, "replace_nil")
             XCTAssertEqual(replaceEmpty, ["replace_empty"])


### PR DESCRIPTION
### Breaking
- Changed some struct to class
- Changed some class names
  - `Distillate` -> `InsecureDistillate`
  - `DistilError` -> `DistillError`
- Changed `CustomStringConvertible` to `CustomDebugStringConvertible`
### Added
- Added some functions
  - `flatMap(Value -> Optional)`
  - `flatMapError(ErrorType -> DistillateType)`
- Added some function that create `Distillate`
  - `Distillate.just(Value)`
  - `Distillate.error(ErrorType)`
  - `Distillate.filter()`
- Added `Distillate` as parent of `DistillateType` classes
- Added `throws` annotation to some closures
### Minor changes
- Change private variable names
