### PR TITLE
Reimplement value/error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,22 @@ let message: String = try j.distil("number_of_apples", as: Int.self)
     .catch { error in "Anything not found... | Error: \(error)" }
 ```
 
+Alembic enable you to receive a value with closure.  
+```Swift
+let jsonObject = ["user": ["name": "Robert Downey, Jr."]]
+let j = JSON(jsonObject)
+```
+```Swift		
+j.distil(["user", "name"], to: String.self)
+    .map { name in "User name is \(name)" }
+    .value { message in
+        print(message)  // "Robert Downey, Jr."
+    }
+    .error { error in
+        print(error)  // NOP
+    }
+```
+
 ### Error handling
 Alembic has powerfull error handling designs as following.  
 It will be help your fail-safe coding.  

--- a/Sources/InsecureDistillate.swift
+++ b/Sources/InsecureDistillate.swift
@@ -23,6 +23,28 @@ public extension InsecureDistillate {
         return try thunk()
     }
     
+    @discardableResult
+    func value(handler: (Value) -> Void) -> InsecureDistillate<Value> {
+        do {
+            let v = try value()
+            handler(v)
+            return .init { v }
+        } catch let e {
+            return .init { throw e }
+        }
+    }
+    
+    @discardableResult
+    func error(handler: (Error) -> Void) -> InsecureDistillate<Value> {
+        do {
+            let v = try value()
+            return .init { v }
+        } catch let e {
+            handler(e)
+            return .init { throw e }
+        }
+    }
+    
     func to(_: Value.Type) throws -> Value {
         return try value()
     }

--- a/Sources/InsecureDistillate.swift
+++ b/Sources/InsecureDistillate.swift
@@ -24,7 +24,7 @@ public extension InsecureDistillate {
     }
     
     @discardableResult
-    func value(handler: (Value) -> Void) -> InsecureDistillate<Value> {
+    func value(_ handler: (Value) -> Void) -> InsecureDistillate<Value> {
         do {
             let v = try value()
             handler(v)
@@ -35,7 +35,7 @@ public extension InsecureDistillate {
     }
     
     @discardableResult
-    func error(handler: (Error) -> Void) -> InsecureDistillate<Value> {
+    func error(_ handler: (Error) -> Void) -> InsecureDistillate<Value> {
         do {
             let v = try value()
             return .init { v }

--- a/Sources/SecureDistillate.swift
+++ b/Sources/SecureDistillate.swift
@@ -23,6 +23,13 @@ public extension SecureDistillate {
         return thunk()
     }
     
+    @discardableResult
+    func value(handler: (Value) -> Void) -> SecureDistillate<Value> {
+        let v = thunk()
+        handler(v)
+        return .init { v }
+    }
+    
     func to(_: Value.Type) -> Value {
         return value()
     }

--- a/Sources/SecureDistillate.swift
+++ b/Sources/SecureDistillate.swift
@@ -24,7 +24,7 @@ public extension SecureDistillate {
     }
     
     @discardableResult
-    func value(handler: (Value) -> Void) -> SecureDistillate<Value> {
+    func value(_ handler: (Value) -> Void) -> SecureDistillate<Value> {
         let v = thunk()
         handler(v)
         return .init { v }

--- a/Tests/AlembicTests/DistilTest.swift
+++ b/Tests/AlembicTests/DistilTest.swift
@@ -61,6 +61,33 @@ class DistilTest: XCTestCase {
         }
     }
     
+    func testDistilHandler() {
+        let j = JSON(object)
+        
+        j.distil(["user", "name"], as: String.self)
+            .value { XCTAssertEqual($0, "ra1028") }
+            .error { XCTFail("\($0)") }
+        
+        j.option("null", as: (String?).self)
+            .value { XCTAssertEqual($0, nil) }
+            .error { XCTFail("\($0)") }
+        
+        j.distil(["user", "name"], as: String.self)
+            .map { s -> String in "User name is " + s }
+            .value { XCTAssertEqual($0, "User name is ra1028") }
+            .error { XCTFail("\($0)") }
+            .filter { _ in false }
+            .value { _ in XCTFail("Expect the error to occur") }
+            .error {
+                if case let DistillError.filteredValue(type, value) = $0 {
+                    XCTAssertNotNil(type as? String.Type)
+                    XCTAssertEqual(value as? String, "User name is ra1028")
+                    return
+                }
+                XCTFail("\($0)")
+        }
+    }
+    
     func testDistillError() {
         let j = JSON(object)
         
@@ -133,6 +160,7 @@ extension DistilTest {
         return [
             ("testDistil", testDistil),
             ("testDistilSubscript", testDistilSubscript),
+            ("testDistilHandler", testDistilHandler),
             ("testDistillError", testDistillError),
             ("testClassMapping", testClassMapping),
             ("testStructMapping", testStructMapping),

--- a/Tests/AlembicTests/TestJSON.swift
+++ b/Tests/AlembicTests/TestJSON.swift
@@ -14,6 +14,7 @@ let distilTestJSONObject: [String: Any] = [
     "double": 77.7,
     "float": 77.7 as Float,
     "bool": true,
+    "null": NSNull(),
     "array": [
         "A", "B", "C"
     ],


### PR DESCRIPTION
## Add
- `InsecureDistillate.value(handler: (Value) -> Void)`
- `InsecureDistillate.error(handler: (Value) -> Void)`
- `SecureDistillate.value(handler: (Value) -> Void)`
