### PR TITLE
Feature/v2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ let value: String = try (j <| "number")(Int.self).map { "Number \($0)" }
 let value: String = try j["number"].distil(as: Int.self).map { "Number \($0)" }
 ```
 
-You can create `Distillate` by `Distillate.filter`, `Distillate.error(error)` and `Distillate.just(value)`.  
+You can create `Distillate` by `Distillate.filter()`, `Distillate.error(error)` and `Distillate.just(value)`.  
 It's provide more convenience to value-transformation.  
 Example:  
 
@@ -478,7 +478,7 @@ struct FindAppleError: Error {}
 
 let message: String = try j.distil("number_of_apples", as: Int.self)
     .flatMap { count -> Distillate<String> in
-        count > 0 ? .just("\(count) apples found!!") : .filter
+        count > 0 ? .just("\(count) apples found!!") : .filter()
     }
     .flatMapError { _ in .error(FindAppleError()) }
     .catch { error in "Anything not found... | Error: \(error)" }

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ __DistillError__
 - missingPath(Path)  
 - typeMismatch(expected: Any.Type, actual: Any, path: Path)  
 - filteredValue(type: Any.Type, value: Any)  
-- failedToSerialize(with: Any)  
+- serializeFailed(with: Any)  
 
 <table>
 <thead>

--- a/Sources/DistillError.swift
+++ b/Sources/DistillError.swift
@@ -10,7 +10,7 @@ public enum DistillError: Error {
     case missingPath(Path)
     case typeMismatch(expected: Any.Type, actual: Any, path: Path)
     case filteredValue(type: Any.Type, value: Any)
-    case failedToSerialize(with: Any)
+    case serializeFailed(with: Any)
 }
 
 // MARK: - CustomStringConvertible
@@ -24,8 +24,8 @@ extension DistillError: CustomStringConvertible {
             return "typeMismatch(expected: \(expected), actual: \(type(of: actual))(\(actual)), path: \(path))"
         case let .filteredValue(type: type, value: value):
             return "filteredValue(type: \(type), value: \(value))"
-        case let .failedToSerialize(with: with):
-            return "failedToSerialize(with: \(type(of: with))(\(with)))"
+        case let .serializeFailed(with: with):
+            return "serializeFailed(with: \(type(of: with))(\(with)))"
         }
     }
 }

--- a/Sources/Distillate+Creation.swift
+++ b/Sources/Distillate+Creation.swift
@@ -7,7 +7,7 @@
 //
 
 public extension Distillate {
-    static var filter: InsecureDistillate<Value> {
+    static func filter() -> InsecureDistillate<Value> {
         return error(DistillError.filteredValue(type: Value.self, value: ()))
     }
     

--- a/Sources/Distillate.swift
+++ b/Sources/Distillate.swift
@@ -7,42 +7,51 @@
 //
 
 public class Distillate<Value> {
+    private var cached: Value?
+    
     init() {}
     
     func _value() throws -> Value {
         fatalError("Abstract method")
     }
+    
+    fileprivate func value() throws -> Value {
+        if let cached = cached { return cached }
+        let value = try _value()
+        self.cached = value
+        return value
+    }
 }
 
 public extension Distillate {
-    func map<T>(_ selector: (Value) throws -> T) throws -> T {
-        return try selector(_value())
+    func map<T>(_ transform: (Value) throws -> T) throws -> T {
+        return try transform(value())
     }
     
-    func map<T>(_ selector: @escaping (Value) throws -> T) -> InsecureDistillate<T> {
-        return .init { try self.map(selector) }
+    func map<T>(_ transform: @escaping (Value) throws -> T) -> InsecureDistillate<T> {
+        return .init { try self.map(transform) }
     }
     
-    func flatMap<T, U: Distillate<T>>(_ selector: (Value) throws -> U) throws -> T {
-        return try map(selector)._value()
+    func flatMap<T, U: Distillate<T>>(_ transform: (Value) throws -> U) throws -> T {
+        return try map(transform).value()
     }
     
-    func flatMap<T, U: Distillate<T>>(_ selector: @escaping (Value) throws -> U) -> InsecureDistillate<T> {
-        return .init { try self.flatMap(selector) }
+    func flatMap<T, U: Distillate<T>>(_ transform: @escaping (Value) throws -> U) -> InsecureDistillate<T> {
+        return .init { try self.flatMap(transform) }
     }
     
-    func flatMap<T>(_ selector: (Value) throws -> T?) throws -> T {
-        let optional = try map(selector)
+    func flatMap<T>(_ transform: (Value) throws -> T?) throws -> T {
+        let optional = try map(transform)
         guard let v = optional else { throw DistillError.filteredValue(type: T.self, value: optional) }
         return v
     }
     
-    func flatMap<T>(_ selector: @escaping (Value) throws -> T?) -> InsecureDistillate<T> {
-        return .init { try self.flatMap(selector) }
+    func flatMap<T>(_ transform: @escaping (Value) throws -> T?) -> InsecureDistillate<T> {
+        return .init { try self.flatMap(transform) }
     }
     
     func filter(_ predicate: (Value) throws -> Bool) throws -> Value {
-        let v = try _value()
+        let v = try value()
         guard try predicate(v) else { throw DistillError.filteredValue(type: Value.self, value: v) }
         return v
     }

--- a/Sources/InsecureDistillate.swift
+++ b/Sources/InsecureDistillate.swift
@@ -59,7 +59,7 @@ public extension InsecureDistillate {
     }
     
     func `catch`(_ handler: @escaping (Error) -> Value) -> SecureDistillate<Value> {
-        return .init(self.catch(handler))
+        return .init { self.catch(handler) }
     }
     
     func `catch`(_ element: @autoclosure () -> Value) -> Value {

--- a/Sources/InsecureDistillate.swift
+++ b/Sources/InsecureDistillate.swift
@@ -7,22 +7,26 @@
 //
 
 public final class InsecureDistillate<Value>: Distillate<Value> {
-    fileprivate let thunk: () throws -> Value
+    private let evaluate: () throws -> Value
+    private var cached: Value?
     
-    init(_ thunk: @escaping () throws -> Value) {
-        self.thunk = thunk
+    init(_ evaluate: @escaping () throws -> Value) {
+        self.evaluate = evaluate
     }
     
     override func _value() throws -> Value {
         return try value()
     }
+    
+    public func value() throws -> Value {
+        if let cached = cached { return cached }
+        let value = try evaluate()
+        self.cached = value
+        return value
+    }
 }
 
 public extension InsecureDistillate {
-    func value() throws -> Value {
-        return try thunk()
-    }
-    
     @discardableResult
     func value(_ handler: (Value) -> Void) -> InsecureDistillate<Value> {
         do {
@@ -55,7 +59,7 @@ public extension InsecureDistillate {
     }
     
     func `catch`(_ handler: @escaping (Error) -> Value) -> SecureDistillate<Value> {
-        return .init { self.catch(handler) }
+        return .init(self.catch(handler))
     }
     
     func `catch`(_ element: @autoclosure () -> Value) -> Value {

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -108,19 +108,15 @@ extension JSON: CustomDebugStringConvertible {
 
 private extension JSON {
     func distilRecursive<T>(path: Path) throws -> T {
-        var distilledPath: Path = []
-        
         func cast<T>(_ object: Any) throws -> T {
             guard let value = object as? T else {
-                throw DistillError.typeMismatch(expected: T.self, actual: object, path: distilledPath)
+                throw DistillError.typeMismatch(expected: T.self, actual: object, path: path)
             }
             return value
         }
         
         func distilRecursive(object: Any, elements: ArraySlice<PathElement>) throws -> Any {
             guard let first = elements.first else { return object }
-            
-            distilledPath = distilledPath + .init(element: first)
             
             switch first {
             case let .key(key):

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -29,7 +29,7 @@ public final class JSON {
             do {
                 return try JSONSerialization.jsonObject(with: data, options: options)
             } catch {
-                throw DistillError.failedToSerialize(with: data)
+                throw DistillError.serializeFailed(with: data)
             }
         }
     }
@@ -41,13 +41,13 @@ public final class JSON {
         options: JSONSerialization.ReadingOptions = .allowFragments) {
         self.init(raw: string) {
             guard let data = string.data(using: encoding, allowLossyConversion: allowLossyConversion) else {
-                throw DistillError.failedToSerialize(with: string)
+                throw DistillError.serializeFailed(with: string)
             }
             
             do {
                 return try JSONSerialization.jsonObject(with: data, options: options)
             } catch {
-                throw DistillError.failedToSerialize(with: string)
+                throw DistillError.serializeFailed(with: string)
             }
         }
     }

--- a/Sources/SecureDistillate.swift
+++ b/Sources/SecureDistillate.swift
@@ -7,27 +7,32 @@
 //
 
 public final class SecureDistillate<Value>: Distillate<Value> {
-    fileprivate let thunk: () -> Value
+    private let evaluate: () -> Value
+    private lazy var cached: Value = self.evaluate()
     
-    init(_ thunk: @escaping () -> Value) {
-        self.thunk = thunk
+    init(_ evaluate: @escaping () -> Value) {
+        self.evaluate = evaluate
+    }
+    
+    convenience init(_ value: @autoclosure @escaping () -> Value) {
+        self.init(value)
     }
     
     override func _value() throws -> Value {
         return value()
     }
+    
+    public func value() -> Value {
+        return cached
+    }
 }
 
 public extension SecureDistillate {
-    func value() -> Value {
-        return thunk()
-    }
-    
     @discardableResult
     func value(_ handler: (Value) -> Void) -> SecureDistillate<Value> {
-        let v = thunk()
+        let v = value()
         handler(v)
-        return .init { v }
+        return .init(v)
     }
     
     func to(_: Value.Type) -> Value {

--- a/Sources/SecureDistillate.swift
+++ b/Sources/SecureDistillate.swift
@@ -14,10 +14,6 @@ public final class SecureDistillate<Value>: Distillate<Value> {
         self.evaluate = evaluate
     }
     
-    convenience init(_ value: @autoclosure @escaping () -> Value) {
-        self.init(value)
-    }
-    
     override func _value() throws -> Value {
         return value()
     }
@@ -32,7 +28,7 @@ public extension SecureDistillate {
     func value(_ handler: (Value) -> Void) -> SecureDistillate<Value> {
         let v = value()
         handler(v)
-        return .init(v)
+        return .init { v }
     }
     
     func to(_: Value.Type) -> Value {

--- a/Tests/AlembicTests/SerializeTest.swift
+++ b/Tests/AlembicTests/SerializeTest.swift
@@ -49,7 +49,7 @@ class SerializeTest: XCTestCase {
             _ = try j.distil("key1", as: String.self)
             
             XCTFail("Expect the error to occur")
-        } catch let DistillError.failedToSerialize(with: with) {
+        } catch let DistillError.serializeFailed(with: with) {
             XCTAssertEqual(with as? String, "")
         } catch let e {
             XCTFail("\(e)")
@@ -63,7 +63,7 @@ class SerializeTest: XCTestCase {
             _ = try j.distil("key1", as: String.self)
             
             XCTFail("Expect the error to occur")
-        } catch let DistillError.failedToSerialize(with: with) {
+        } catch let DistillError.serializeFailed(with: with) {
             XCTAssertEqual(with as? Data, Data())
         } catch let e {
             XCTFail("\(e)")

--- a/Tests/AlembicTests/TransformTest.swift
+++ b/Tests/AlembicTests/TransformTest.swift
@@ -119,7 +119,7 @@ class TransformTest: XCTestCase {
         let j = JSON(object)
         
         let just = Distillate.just("just")
-        XCTAssertEqual(just.to(String.self), "just")
+        XCTAssertEqual(just.value(), "just")
         
         do {
             _ = try Distillate<String>.filter.to(String.self)

--- a/Tests/AlembicTests/TransformTest.swift
+++ b/Tests/AlembicTests/TransformTest.swift
@@ -122,7 +122,7 @@ class TransformTest: XCTestCase {
         XCTAssertEqual(just.value(), "just")
         
         do {
-            _ = try Distillate<String>.filter.to(String.self)
+            _ = try Distillate<String>.filter().to(String.self)
             
             XCTFail("Expect the error to occur")
         } catch let DistillError.filteredValue(type: type, value: value) {
@@ -133,7 +133,7 @@ class TransformTest: XCTestCase {
         }
         
         do {
-            _ = try Distillate.filter.to(String.self)
+            _ = try Distillate.filter().to(String.self)
             
             XCTFail("Expect the error to occur")
         } catch let DistillError.filteredValue(type: type, value: value) {
@@ -153,7 +153,7 @@ class TransformTest: XCTestCase {
         
         do {
             _ = try (j <| "key")(String.self)
-                .flatMap { _ in .filter }
+                .flatMap { _ in .filter() }
                 .to(String.self)
             
             XCTFail("Expect the error to occur")


### PR DESCRIPTION
### Improvement
- Value of `JSON` and `Distillate` to be caching
- Improve the behavior of `Path` value included in `DistillError.typeMismatch`
### Breaking
#### Rename
- `failedToSerialize` -> `serializeFailed`  
#### Changes
- `Distillate.filter` is now function `Distillate.filter()`
